### PR TITLE
 feat: add the configuration "http_method"

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,14 @@ ignore_urls:
   - https://github.com/suzuki-shunsuke/ignore-repository
 ignore_hosts:
   - localhost.com
+http_method: head,get
 ```
+
+`http_method` is the HTTP method used to check urls.
+
+* "head,get", "" (default): check by HEAD method and if it is failure check by GET method
+* "get": the GET method
+* "head": the HEAD method
 
 ## Change Log
 

--- a/internal/domain/const.go
+++ b/internal/domain/const.go
@@ -14,6 +14,8 @@ const (
 # https://github.com/suzuki-shunsuke/durl
 ignore_urls:
 - https://github.com/suzuki-shunsuke/durl
+ignore_hosts: []
+http_method: head,get
 `
 )
 

--- a/internal/domain/struct.go
+++ b/internal/domain/struct.go
@@ -5,5 +5,6 @@ type (
 	Cfg struct {
 		IgnoreURLs  []string `yaml:"ignore_urls"`
 		IgnoreHosts []string `yaml:"ignore_hosts"`
+		HTTPMethod  string   `yaml:"http_method"`
 	}
 )

--- a/internal/usecase/check.go
+++ b/internal/usecase/check.go
@@ -129,8 +129,8 @@ func checkURLs(urls map[string]*strset.Set) error {
 	return eg.Wait()
 }
 
-func checkURL(ctx context.Context, client http.Client, u string) error {
-	req, err := http.NewRequest(http.MethodGet, u, nil)
+func checkURLWithMethod(ctx context.Context, client http.Client, u, method string) error {
+	req, err := http.NewRequest(method, u, nil)
 	if err != nil {
 		return err
 	}
@@ -145,6 +145,13 @@ func checkURL(ctx context.Context, client http.Client, u string) error {
 		return fmt.Errorf("%s is dead (%d)", u, resp.StatusCode)
 	}
 	return nil
+}
+
+func checkURL(ctx context.Context, client http.Client, u string) error {
+	if err := checkURLWithMethod(ctx, client, u, http.MethodHead); err == nil {
+		return nil
+	}
+	return checkURLWithMethod(ctx, client, u, http.MethodGet)
 }
 
 func extractURLsFromFiles(fsys domain.Fsys, files *strset.Set) (map[string]*strset.Set, error) {

--- a/internal/usecase/check_test.go
+++ b/internal/usecase/check_test.go
@@ -77,7 +77,7 @@ func TestCheck(t *testing.T) {
 		t.Run(tt.title, func(t *testing.T) {
 			g := gock.New("http://github.com")
 			for p, c := range tt.replies {
-				g.Get(p).Reply(c)
+				g.Head(p).Reply(c)
 			}
 			fsys := newFsys(t, tt.files).
 				SetReturnGetwd("/home/foo", nil).
@@ -136,7 +136,7 @@ func Test_checkURLs(t *testing.T) {
 		t.Run(tt.title, func(t *testing.T) {
 			g := gock.New("http://example.com")
 			for p, c := range tt.replies {
-				g.Get(p).Reply(c)
+				g.Head(p).Reply(c)
 			}
 			tt.checkErr(t, checkURLs(tt.urls))
 		})
@@ -167,7 +167,7 @@ func Test_checkURL(t *testing.T) {
 			}
 			host.Path = tt.path
 			gock.New("http://example.com").
-				Get(tt.path).Reply(tt.reply)
+				Head(tt.path).Reply(tt.reply)
 			tt.checkErr(t, checkURL(context.Background(), client, host.String()))
 		})
 	}

--- a/internal/usecase/check_test.go
+++ b/internal/usecase/check_test.go
@@ -132,13 +132,14 @@ func Test_checkURLs(t *testing.T) {
 			"http://example.com/bar": strset.New("bar.txt"),
 		}, require.NotNil,
 	}}
+	cfg := domain.Cfg{HTTPMethod: "head,get"}
 	for _, tt := range data {
 		t.Run(tt.title, func(t *testing.T) {
 			g := gock.New("http://example.com")
 			for p, c := range tt.replies {
 				g.Head(p).Reply(c)
 			}
-			tt.checkErr(t, checkURLs(tt.urls))
+			tt.checkErr(t, checkURLs(cfg, tt.urls))
 		})
 	}
 }
@@ -159,17 +160,20 @@ func Test_checkURL(t *testing.T) {
 	}, {
 		"500 error", "/bar", 500, require.NotNil,
 	}}
-	for _, tt := range data {
-		t.Run(tt.title, func(t *testing.T) {
-			host, err := url.Parse("http://example.com")
-			if err != nil {
-				t.Fatal(err)
-			}
-			host.Path = tt.path
-			gock.New("http://example.com").
-				Head(tt.path).Reply(tt.reply)
-			tt.checkErr(t, checkURL(context.Background(), client, host.String()))
-		})
+	for _, m := range []string{"", "head,get", "get"} {
+		cfg := domain.Cfg{HTTPMethod: m}
+		for _, tt := range data {
+			t.Run(tt.title, func(t *testing.T) {
+				host, err := url.Parse("http://example.com")
+				if err != nil {
+					t.Fatal(err)
+				}
+				host.Path = tt.path
+				gock.New("http://example.com").
+					Get(tt.path).Reply(tt.reply)
+				tt.checkErr(t, checkURL(context.Background(), cfg, client, host.String()))
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
Close #25 

`http_method` is the HTTP method used to check urls.

* "head,get", "" (default): check by HEAD method and if it is failure check by GET method
* "get": the GET method
* "head": the HEAD method