### PR TITLE
 feat: accept multiple request failures

### DIFF
--- a/internal/domain/const.go
+++ b/internal/domain/const.go
@@ -15,6 +15,7 @@ ignore_urls:
 ignore_hosts: []
 http_method: head,get
 max_request_count: 10
+max_failed_request_count: 5
 http_request_timeout: 10
 `
 )

--- a/internal/domain/struct.go
+++ b/internal/domain/struct.go
@@ -3,10 +3,11 @@ package domain
 type (
 	// Cfg represents configuration.
 	Cfg struct {
-		IgnoreURLs         []string `yaml:"ignore_urls"`
-		IgnoreHosts        []string `yaml:"ignore_hosts"`
-		HTTPMethod         string   `yaml:"http_method"`
-		MaxRequestCount    int      `yaml:"max_request_count"`
-		HTTPRequestTimeout int      `yaml:"http_request_timeout"`
+		IgnoreURLs            []string `yaml:"ignore_urls"`
+		IgnoreHosts           []string `yaml:"ignore_hosts"`
+		HTTPMethod            string   `yaml:"http_method"`
+		MaxRequestCount       int      `yaml:"max_request_count"`
+		MaxFailedRequestCount int      `yaml:"max_failed_request_count"`
+		HTTPRequestTimeout    int      `yaml:"http_request_timeout"`
 	}
 )

--- a/internal/usecase/check.go
+++ b/internal/usecase/check.go
@@ -123,6 +123,9 @@ func initCfg(cfg domain.Cfg) (domain.Cfg, error) {
 }
 
 func checkURLs(cfg domain.Cfg, urls map[string]*strset.Set) error {
+	if len(urls) == 0 {
+		return nil
+	}
 	eg, ctx := errgroup.WithContext(context.Background())
 	if cfg.HTTPRequestTimeout == 0 {
 		cfg.HTTPRequestTimeout = domain.DefaultTimeout

--- a/internal/usecase/check.go
+++ b/internal/usecase/check.go
@@ -156,7 +156,7 @@ func checkURLs(cfg domain.Cfg, urls map[string]*strset.Set) error {
 		}()
 	}
 	endCount := len(urls)
-	failedCount := 5
+	failedCount := cfg.MaxFailedRequestCount
 	for {
 		select {
 		case b := <-resultChan:
@@ -165,7 +165,7 @@ func checkURLs(cfg domain.Cfg, urls map[string]*strset.Set) error {
 				failedCount--
 			}
 			if endCount == 0 {
-				if failedCount != 5 {
+				if failedCount != cfg.MaxFailedRequestCount {
 					return fmt.Errorf("")
 				}
 				return nil


### PR DESCRIPTION
Close #26 

Add a configuration `max_failed_request_count`.
If `max_failed_request_count` is `n` and it is failed to check `n+1` urls, exit.